### PR TITLE
Split out common types into descriptor and option packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIN := .tmp/bin
 export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
 
-BUF_VERSION := v1.38.0
+BUF_VERSION := v1.42.0
 COPYRIGHT_YEARS := 2024
 
 .PHONY: help

--- a/buf/plugin/check/v1/annotation.proto
+++ b/buf/plugin/check/v1/annotation.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package buf.plugin.check.v1;
 
-import "buf/plugin/check/v1/location.proto";
+import "buf/plugin/descriptor/v1/file_location.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1";
@@ -42,15 +42,16 @@ message Annotation {
   //
   // Optional.
   string message = 2;
-  // The location of the Failure in a File within the files list.
+  // The location of the failure in a FileDescriptor within the file_descriptors list.
   //
   // Optional.
-  Location location = 3;
-  // The location of the Failure in a File in the against_files list.
+  buf.plugin.descriptor.v1.FileLocation file_location = 3;
+  // The location of the failure in a FileDescriptor in the against_file_descriptors list.
   //
   // Optional.
   //
-  // This may be present even if location is not present. For example, if a File was deleted,
-  // this may reference the deleted File in against_files, while location will not be present.
-  Location against_location = 4;
+  // This may be present even if file_location is not present. For example, if a file was deleted,
+  // this may reference the deleted FileDescriptor in against_file_descriptors, while file_location
+  // will not be present.
+  buf.plugin.descriptor.v1.FileLocation against_file_location = 4;
 }

--- a/buf/plugin/check/v1/check_service.proto
+++ b/buf/plugin/check/v1/check_service.proto
@@ -18,9 +18,9 @@ package buf.plugin.check.v1;
 
 import "buf/plugin/check/v1/annotation.proto";
 import "buf/plugin/check/v1/category.proto";
-import "buf/plugin/check/v1/file.proto";
-import "buf/plugin/check/v1/option.proto";
 import "buf/plugin/check/v1/rule.proto";
+import "buf/plugin/descriptor/v1/file_descriptor.proto";
+import "buf/plugin/option/v1/option.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1";
@@ -28,11 +28,11 @@ option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/
 // The service that defines check operations.
 //
 // A check is a lint or breaking change check. The only difference between lint and breaking
-// change checks from an API standpoint is that breaking change checks also need Files
+// change checks from an API standpoint is that breaking change checks also need FileDescriptors
 // to check against. As such, instead of duplicating the API into two separate services, we
 // combine all checks into a single interface for simplicity of plugin author implementation.
 service CheckService {
-  // Check a set of Files for failures.
+  // Check a set of FileDescriptors for failures.
   //
   // All Annotations returned will have an ID that is contained within a Rule listed by ListRules.
   rpc Check(CheckRequest) returns (CheckResponse) {
@@ -48,36 +48,36 @@ service CheckService {
   }
 }
 
-// A request to check files.
+// A request to check FileDescriptors.
 message CheckRequest {
-  // The Files to check.
+  // The FileDescriptors to check.
   //
   // Required.
   //
-  // Files are guaranteed to be unique by file_descriptor_proto.name.
-  repeated File files = 1 [
+  // FileDescriptors are guaranteed to be unique by file_descriptor_proto.name.
+  repeated buf.plugin.descriptor.v1.FileDescriptor file_descriptors = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).cel = {
-      id: "file_names_unique"
-      message: "file names must be unique"
-      expression: "this.filter(file, has(file.file_descriptor_proto)).map(file, file.file_descriptor_proto.name).unique()"
+      id: "file_descriptor_names_unique"
+      message: "FileDescriptor names must be unique"
+      expression: "this.filter(file_descriptor, has(file_descriptor.file_descriptor_proto)).map(file_descriptor, file_descriptor.file_descriptor_proto.name).unique()"
     }
   ];
-  // The Files to check against.
+  // The FileDescriptors to check against.
   //
   // Optional.
   //
-  // This is usually the state of the Files at a previous VCS commit, or the state of
-  // the Files at a release tag.
+  // This is usually the state of the FileDescriptors at a previous VCS commit, or the state of
+  // the FileDescriptors at a release tag.
   //
-  // Files are guaranteed to be unique by file_descriptor_proto.name.
+  // FileDescriptors are guaranteed to be unique by file_descriptor_proto.name.
   //
   // Note that this may be empty, even for breaking change checks, to account for
-  // going from the empty state to the first set of Files.
-  repeated File against_files = 2 [(buf.validate.field).cel = {
-    id: "file_names_unique"
-    message: "file names must be unique"
-    expression: "this.filter(file, has(file.file_descriptor_proto)).map(file, file.file_descriptor_proto.name).unique()"
+  // going from the empty state to the first set of FileDescriptors.
+  repeated buf.plugin.descriptor.v1.FileDescriptor against_file_descriptors = 2 [(buf.validate.field).cel = {
+    id: "file_descriptor_names_unique"
+    message: "FileDescriptor names must be unique"
+    expression: "this.filter(file_descriptor, has(file_descriptor.file_descriptor_proto)).map(file_descriptor, file_descriptor.file_descriptor_proto.name).unique()"
   }];
   // Options for the Rules.
   //
@@ -90,7 +90,7 @@ message CheckRequest {
   // describe the available options keys, which can then be validated against.
   //
   // It is acceptable for a plugin to return an error on an unknown or misconstructed Option.
-  repeated Option options = 3;
+  repeated buf.plugin.option.v1.Option options = 3;
   // The IDs of the Rules to check.
   //
   // Optional. If not specified, all Rules returned by ListRules are checked.

--- a/buf/plugin/check/v1/rule.proto
+++ b/buf/plugin/check/v1/rule.proto
@@ -23,8 +23,8 @@ option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/
 // The type of the Rule.
 //
 // Currently, there are only two types of rules: lint rules, and breaking change rules.
-// Breaking change rules require files to check against; if the Rule ID of a breaking change
-// Rule is specified in a Check call, then against_files are required.
+// Breaking change rules require FileDescriptors to check against; if the Rule ID of a breaking change
+// Rule is specified in a Check call, then against_file_descriptors are required.
 enum RuleType {
   // The unspecified value.
   RULE_TYPE_UNSPECIFIED = 0;

--- a/buf/plugin/descriptor/v1/file_descriptor.proto
+++ b/buf/plugin/descriptor/v1/file_descriptor.proto
@@ -14,24 +14,23 @@
 
 syntax = "proto3";
 
-package buf.plugin.check.v1;
+package buf.plugin.descriptor.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/descriptor.proto";
 
-option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1";
+option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/descriptor/v1";
 
-// A File to check.
+// A file descriptor.
 //
-// A File is represented as a FileDescriptorProto, with the additional property of whether
+// A FileDescriptor is represented as a FileDescriptorProto, with the additional property of whether
 // or not the File is an import.
-message File {
+message FileDescriptor {
   // The FileDescriptorProto that represents the file.
   //
   // Required.
   //
   // This will always contain SourceCodeInfo.
-  // All files will be unique by name.
   google.protobuf.FileDescriptorProto file_descriptor_proto = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).cel = {

--- a/buf/plugin/descriptor/v1/file_location.proto
+++ b/buf/plugin/descriptor/v1/file_location.proto
@@ -14,28 +14,28 @@
 
 syntax = "proto3";
 
-package buf.plugin.check.v1;
+package buf.plugin.descriptor.v1;
 
 import "buf/validate/validate.proto";
 
-option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1";
+option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/descriptor/v1";
 
-// A reference to a File or to a location within a File.
+// A reference to a FileDescriptor or to a location within a FileDescriptor.
 //
-// A File is referenced by name.
+// A FileDescriptor is referenced by name.
 // A location is referenced by its source path, following the semantics of
 // google.protobuf.SourceCodeInfo.Location.path.
 //
 // A Location may or may not include a source path. If a source path is not included, the
-// Location just references the File as a whole.
-message Location {
+// Location just references the FileDescriptor as a whole.
+message FileLocation {
   option (buf.validate.message).cel = {
     id: "file_name_present_if_source_path_present"
     message: "file_name must be present if source_path is present"
     expression: "!has(this.source_path) || (has(this.source_path) && has(this.file_name))"
   };
 
-  // The name of the File. This matches the name field in the corresponding FileDescriptorProto.
+  // The name of the FileDescriptor. This matches the name field in the corresponding FileDescriptorProto.
   //
   // Required.
   //

--- a/buf/plugin/option/v1/option.proto
+++ b/buf/plugin/option/v1/option.proto
@@ -14,18 +14,17 @@
 
 syntax = "proto3";
 
-package buf.plugin.check.v1;
+package buf.plugin.option.v1;
 
 import "buf/validate/validate.proto";
 
-option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1";
+option go_package = "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/option/v1";
 
-// An option for a Rule.
+// An option for a plugin.
 //
-// Options are key/values that can control the behavior of a Rule when run with Check,
-// and can control the value of the Purpose string of the Rule.
+// Options are key/values that can control the behavior of a plugin.
 //
-// For example, if you had a Rule that checked that the suffix of all Services was "API",
+// For example, if you had a check Rule that checked that the suffix of all Services was "API",
 // you may want an option with key "service_suffix" that can override the suffix "API" to
 // another suffix such as "Service". This would result in the behavior of check changing,
 // as well as result in the Purpose string potentially changing to specify that the


### PR DESCRIPTION
In preparation for additional plugin types, this does some refactoring:

- Move `buf.plugin.check.v1.File` to `buf.plugin.descriptor.v1.FileDescriptor`.
- Move `buf.plugin.check.v1.Location` to `buf.plugin.descriptor.v1.FileLocation`.
- Move `buf.plugin.check.v1.Options` to `buf.plugin.option.v1.Options`.
- Rename fields as appropriate.