### PR TITLE
Add documentation link to check annotation

### DIFF
--- a/buf/plugin/check/v1/annotation.proto
+++ b/buf/plugin/check/v1/annotation.proto
@@ -58,4 +58,12 @@ message Annotation {
   //
   // Optional.
   string documentation_link = 5;
+  // An optional identifier that can help refine exactly how the rule was violated.
+  //
+  // Optional.
+  //
+  // Simple rules will probably not require this level of detail because it is obvious, but
+  // for more complex logic (such as checks involving external systems), it can be helpful to
+  // provide an identifier that narrows down why the rule failed.
+  string failure_code = 6;
 }

--- a/buf/plugin/check/v1/annotation.proto
+++ b/buf/plugin/check/v1/annotation.proto
@@ -54,4 +54,8 @@ message Annotation {
   // this may reference the deleted FileDescriptor in against_file_descriptors, while file_location
   // will not be present.
   buf.plugin.descriptor.v1.FileLocation against_file_location = 4;
+  // A URL that provides more human-readable information about the rule in question.
+  //
+  // Optional.
+  string documentation_link = 5;
 }


### PR DESCRIPTION
Adding the ability to add a documentation link to annotations (fixes #10, and precursor to fixing https://github.com/bufbuild/buf/issues/4422).

I've also added a general-purpose qualifier field to facilitate rule-refinement in some way. I anticipate using this to capture [api-linter](https://linter.aip.dev/)'s rules, but it would also be useful if checking against external systems that require extra context as to the reason of a failure and want to carry that through to the user.